### PR TITLE
Work List Completed - See Comments for Multi Repo

### DIFF
--- a/src/client/smgr_add.py
+++ b/src/client/smgr_add.py
@@ -352,6 +352,8 @@ def add_payload(object, default_object):
                             if disks:
                                 disk_list = disks.split(',')
                                 user_input = [str(d) for d in disk_list]
+                            else:
+                                user_input = None
                         params_dict[key_selected] = user_input
                     elif key_selected == "roles":
                         msg = index_dict[eval(user_selection)] + ":"
@@ -407,6 +409,8 @@ def add_payload(object, default_object):
                             if disks:
                                 disk_list = disks.split(',')
                                 user_input = [str(d) for d in disk_list]
+                            else:
+                                user_input = None
                         else:
                             user_input = raw_input(msg)
                         if user_input:

--- a/src/server_mgr_main.py
+++ b/src/server_mgr_main.py
@@ -2072,8 +2072,10 @@ class VncServerManager():
             for server in servers:
                 server_params = eval(server['server_params'])
                 server_roles = eval(server['roles'])
-                if 'storage' in server_roles:
+                if 'storage' in server_roles and 'disks' in server_params:
                     total_osd += len(server_params['disks'])
+                else:
+                    total_osd = 0
 
             packages = self._serverDb.get_image("image_id", package_image_id, True)
             if len(packages) == 0:
@@ -2232,8 +2234,9 @@ class VncServerManager():
                 for x in role_servers['storage']:
                     hosts_dict[x["server_id"]] = [x["server_id"], x["ip"]]
                 provision_params['storage_monitor_hosts'] = hosts_dict
-                provision_params['storage_server_disks'] = []
-                provision_params['storage_server_disks'].extend(server_params['disks'])
+                if 'disks' in server_params and total_osd > 0:
+                    provision_params['storage_server_disks'] = []
+                    provision_params['storage_server_disks'].extend(server_params['disks'])
 
                 self._do_provision_server(provision_params)
                 #end of for


### PR DESCRIPTION
Work List Completed 
- Verified that disks are not mandatory 
- Tested by adding and provisioning server with and without disks defined in JSON
- In CLI just hit enter
  For Multi Repo:
  The parameters passed to puppet resources need to be replaced with global variables declared at the top of the manifest.
  The global parameters are generated first - from a dictionary containing the parameters for ALL resources in that manifest.
  Contact Thilak for further questions
