### PR TITLE
[1359074] - Add confirmation message for operational commands -

### DIFF
--- a/src/client/smgr_provision_server.py
+++ b/src/client/smgr_provision_server.py
@@ -58,6 +58,9 @@ def parse_arguments(args_str=None):
     group.add_argument("--interactive", "-I", action="store_true", 
                         help=("flag that user wants to enter the server "
                              " parameters for provisioning manually"))
+    parser.add_argument("--no_confirm", "-F", action="store_true",
+                        help=("flag to bypass confirmation message, "
+                              "default = do not bypass"))
     args = parser.parse_args(args_str)
     return args
 
@@ -152,6 +155,18 @@ def provision_server(args_str=None):
         payload[match_key] = match_value
     if provision_params:
         payload['provision_params'] = provision_params
+
+    if (not args.no_confirm):
+        if match_key:
+            msg = "Provision servers (%s:%s) with %s? (y/N) :" %(
+                match_key, match_value, args.package_image_id)
+        else:
+            msg = "Provision servers with %s? (y/N) :" %(
+                args.package_image_id)
+        user_input = raw_input(msg).lower()
+        if user_input not in ["y", "yes"]:
+            sys.exit()
+    # end if
  
     resp = send_REST_request(smgr_ip, smgr_port,
                              payload)

--- a/src/client/smgr_reimage_server.py
+++ b/src/client/smgr_reimage_server.py
@@ -59,6 +59,9 @@ def parse_arguments(args_str=None):
     group.add_argument("--tag",
                         help=("tag values for the servers to be reimaged"
                               "in t1=v1,t2=v2,... format"))
+    parser.add_argument("--no_confirm", "-F", action="store_true",
+                        help=("flag to bypass confirmation message, "
+                              "default = do not bypass"))
     args = parser.parse_args(args_str)
     return args
 # end parse arguments
@@ -121,6 +124,14 @@ def reimage_server(args_str=None):
         payload['no_reboot'] = "y"
     if match_key:
         payload[match_key] = match_value
+
+    if (not args.no_confirm):
+        msg = "Reimage servers (%s:%s) with %s? (y/N) :" %(
+            match_key, match_value, args.base_image_id)
+        user_input = raw_input(msg).lower()
+        if user_input not in ["y", "yes"]:
+            sys.exit()
+    # end if
  
     resp = send_REST_request(smgr_ip, smgr_port,
                              payload)

--- a/src/client/smgr_restart_server.py
+++ b/src/client/smgr_restart_server.py
@@ -53,6 +53,9 @@ def parse_arguments(args_str=None):
     parser.add_argument("--net_boot", "-n", action="store_true",
                         help=("optional parameter to indicate"
                              " if server should be netbooted."))
+    parser.add_argument("--no_confirm", "-F", action="store_true",
+                        help=("flag to bypass confirmation message, "
+                              "default = do not bypass"))
     args = parser.parse_args(args_str)
     return args
 # end def parse_arguments
@@ -113,6 +116,14 @@ def restart_server(args_str=None):
         payload[match_key] = match_value
     if (args.net_boot):
         payload['net_boot'] = "y"
+
+    if (not args.no_confirm):
+        msg = "Restart servers (%s:%s)? (y/N) :" %(
+            match_key, match_value)
+        user_input = raw_input(msg).lower()
+        if user_input not in ["y", "yes"]:
+            sys.exit()
+    # end if
  
     resp = send_REST_request(smgr_ip, smgr_port,
                              payload)

--- a/src/server_mgr_main.py
+++ b/src/server_mgr_main.py
@@ -744,7 +744,7 @@ class VncServerManager():
         elif len(entity) == 1:
             match_key, match_value = entity.popitem()
             # check that match key is a valid one
-            if (match_key not in ("server_id", "mac_address",
+            if (match_key not in ("id", "mac_address",
                                   "tag", "cluster_id")):
                 msg = "Invalid Query arguments"
                 raise ServerMgrException(msg)


### PR DESCRIPTION
reimage, restart and provision. Also there is optional parameter
--no_confirm or -F. If this is specified, the confirmation message
is bypassed.
