### PR TITLE
[1365112] When provision CLI command is invoked, it exits with error "In...

### DIFF
--- a/src/client/smgr_provision_server.py
+++ b/src/client/smgr_provision_server.py
@@ -154,7 +154,7 @@ def provision_server(args_str=None):
     if match_key:
         payload[match_key] = match_value
     if provision_params:
-        payload['provision_params'] = provision_params
+        payload['provision_parameters'] = provision_params
 
     if (not args.no_confirm):
         if match_key:

--- a/src/server_mgr_main.py
+++ b/src/server_mgr_main.py
@@ -690,6 +690,7 @@ class VncServerManager():
                 raise ServerMgrException(msg)
             ret_data["status"] = 0
             ret_data["servers"] = servers
+            ret_data["package_image_id"] = package_image_id
         else:
             if (len(entity) == 0):
                 msg = "No servers specified"


### PR DESCRIPTION
...valid Query arguments".
